### PR TITLE
Bugfix index shift on getNextOutput

### DIFF
--- a/testsrc/tools/sapcx/commerce/toolkit/testing/testdoubles/datamapping/ConverterSpy.java
+++ b/testsrc/tools/sapcx/commerce/toolkit/testing/testdoubles/datamapping/ConverterSpy.java
@@ -66,11 +66,11 @@ public class ConverterSpy<INPUT, OUTPUT> implements Converter<INPUT, OUTPUT> {
 	}
 
 	private OUTPUT getNextOutput() {
-		if (++outputsCounter == this.outputs.size()) {
+		if (outputsCounter == this.outputs.size()) {
 			outputsCounter = 0;
 		}
 
-		OUTPUT output = this.outputs.get(outputsCounter);
+		OUTPUT output = this.outputs.get(outputsCounter++);
 		deliveredOutputs.add(output);
 		return output;
 	}


### PR DESCRIPTION
When several objects were stored in outputs list, the first call to getNextOutput returned the 2nd of those objects, the second call the 3rd etc.